### PR TITLE
Fix "IndexError" issue in retrieving blob IDs

### DIFF
--- a/driveanon/driveanon.py
+++ b/driveanon/driveanon.py
@@ -69,9 +69,10 @@ def request_folder_blob(folder_blob_id):
 def find_content_block(html_response, extension):
     content_block = []
     for element in html_response.find_all('script'):
-        if '_DRIVE_ivd' in element.text:
-            if extension in element.text:
+        if '_DRIVE_ivd' in str(element.contents):
+            if extension in str(element.contents):
                 content_block.append(element)
+    print(content_block)
     return content_block
 
 def extract_file_indices(content_block, extension):

--- a/driveanon/driveanon.py
+++ b/driveanon/driveanon.py
@@ -72,7 +72,6 @@ def find_content_block(html_response, extension):
         if '_DRIVE_ivd' in str(element.contents):
             if extension in str(element.contents):
                 content_block.append(element)
-    print(content_block)
     return content_block
 
 def extract_file_indices(content_block, extension):


### PR DESCRIPTION
**Problem:** Recently noticed that list_blobs was failing with an "IndexError: list index out of range" where within find_content_block, element.text was returning nothing. This resulted in content_block being an empty list, therefore when we try content_block[0] it raises the index error.

![indexerror](https://user-images.githubusercontent.com/650301/79913204-19f6ca00-83d8-11ea-80cb-b244016af8f1.png)

**Fix:** Replacing occurances of element.text with str(element.contents) seems to fix this problem.

I'm not sure if this is due to some change on the Google Drive side, or something different with BeautifulSoup?

